### PR TITLE
fix: add registry table for staging

### DIFF
--- a/content/blog/Publishing_to_crates_io.md
+++ b/content/blog/Publishing_to_crates_io.md
@@ -182,6 +182,7 @@ In addition to signing up at [https://staging.crates.io](https://staging.crates.
 
 Edit or create your `~/.cargo/config` file and add the following entry:
 ```toml
+[registries]
 staging = { index = "https://github.com/rust-lang/staging.crates.io-index" }
 ```
 


### PR DESCRIPTION
Hi! I was following along in your [article](https://www.printlnhello.world/blog/publishing-to-crates-io/#then-do-it-again-on-staging) and noticed I couldn't publish to http://staging.crates.io. I kept getting the error:
```console
error: no index found for registry: `staging`
```
Did some [searching](https://doc.rust-lang.org/cargo/reference/registries.html#using-an-alternate-registry) and noticed the `[registries]` table was missing.

Also, thanks for the fantastic article! 😄 